### PR TITLE
引入了Altcha进行人机验证

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@
 - [ ] support-4: 支持油猴脚本，Mac用户可以通过油猴脚本使用插件 [*on work*]
 - [x] support-5: 上架edge应用商店
 
-- [ ] new feature-1: 频繁vote时增加人机验证，感谢B站用户 巧克力棒好好吃啊qwq 的建议
+- [x] new feature-1: 频繁vote时增加人机验证，感谢B站用户 巧克力棒好好吃啊qwq 的建议
 - [ ] new feature-2: 将榜单制作为一个独立的页面，方便用户查看和分享 [*on work*]
 - [ ] new feature-3: 由用户决定是否发送？弹幕
 

--- a/src/bili-qml-extension/popup.js
+++ b/src/bili-qml-extension/popup.js
@@ -4,13 +4,89 @@ const API_BASE = 'https://www.bili-qml.top/api';
 document.addEventListener('DOMContentLoaded', () => {
     const leaderboard = document.getElementById('leaderboard');
     const tabs = document.querySelectorAll('.tab-btn');
+    let currentRange = 'realtime';
 
-    async function fetchLeaderboard(range = 'realtime') {
+    // 加载 Altcha widget 脚本
+    function loadAltchaScript() {
+        return new Promise((resolve) => {
+            if (document.querySelector('script[src*="altcha"]')) {
+                resolve();
+                return;
+            }
+            const script = document.createElement('script');
+            script.src = 'https://cdn.jsdelivr.net/npm/altcha@latest/dist/altcha.min.js';
+            script.type = 'module';
+            script.async = true;
+            script.onload = resolve;
+            document.head.appendChild(script);
+        });
+    }
+
+    // 显示验证界面
+    async function showCaptchaUI() {
+        await loadAltchaScript();
+
+        return new Promise((resolve, reject) => {
+            leaderboard.innerHTML = `
+                <div class="captcha-container" style="padding: 20px; text-align: center;">
+                    <p style="margin-bottom: 16px; color: #61666d;">🤖 请求过于频繁，请完成验证</p>
+                    <altcha-widget 
+                        challengeurl="${API_BASE}/altcha/challenge"
+                        hidelogo
+                        hidefooter
+                    ></altcha-widget>
+                    <button id="cancel-captcha" style="
+                        margin-top: 16px;
+                        padding: 8px 16px;
+                        border: 1px solid #ddd;
+                        border-radius: 4px;
+                        background: #f5f5f5;
+                        cursor: pointer;
+                    ">取消</button>
+                </div>
+            `;
+
+            // 等待 widget 初始化
+            setTimeout(() => {
+                const widget = leaderboard.querySelector('altcha-widget');
+                if (widget) {
+                    widget.addEventListener('verified', (e) => {
+                        resolve(e.detail.payload);
+                    });
+                }
+            }, 100);
+
+            document.getElementById('cancel-captcha')?.addEventListener('click', () => {
+                reject(new Error('用户取消验证'));
+            });
+        });
+    }
+
+    async function fetchLeaderboard(range = 'realtime', altchaPayload = null) {
+        currentRange = range;
         leaderboard.innerHTML = '<div class="loading">加载中...</div>';
+
         try {
-            const response = await fetch(`${API_BASE}/leaderboard?range=${range}`);
+            let url = `${API_BASE}/leaderboard?range=${range}`;
+            if (altchaPayload) {
+                url += `&altcha=${encodeURIComponent(altchaPayload)}`;
+            }
+
+            const response = await fetch(url);
             const data = await response.json();
-            
+
+            // 检查是否需要人机验证
+            if (data.requiresCaptcha) {
+                try {
+                    const payload = await showCaptchaUI();
+                    // 验证成功，重新请求
+                    return fetchLeaderboard(range, payload);
+                } catch (captchaError) {
+                    leaderboard.innerHTML = '<div class="loading">已取消验证</div>';
+                    return;
+                }
+            }
+
             if (data.success && data.list.length > 0) {
                 renderList(data.list);
             } else {
@@ -46,6 +122,6 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     });
 
-    // 默认加载日榜
+    // 默认加载实时榜
     fetchLeaderboard();
 });

--- a/src/server/package-lock.json
+++ b/src/server/package-lock.json
@@ -8,6 +8,7 @@
       "name": "bili-qmr-server",
       "version": "1.0.0",
       "dependencies": {
+        "altcha-lib": "^0.5.0",
         "body-parser": "^1.20.2",
         "cors": "^2.8.5",
         "express": "^4.18.2",
@@ -27,6 +28,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/altcha-lib": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/altcha-lib/-/altcha-lib-0.5.1.tgz",
+      "integrity": "sha512-dW3g79ZoXRh2/fDBUj+T9rKWFyDMwxIAPdCOuQ7rAe4RIwXNMEiJHrXPZhmj7aALTKRqHCmMB4BMBkyBe1+gww==",
+      "license": "MIT"
     },
     "node_modules/array-flatten": {
       "version": "1.1.1",

--- a/src/server/package.json
+++ b/src/server/package.json
@@ -8,7 +8,8 @@
     "cors": "^2.8.5",
     "body-parser": "^1.20.2",
     "moment": "^2.29.4",
-    "lowdb": "^1.0.0"
+    "lowdb": "^1.0.0",
+    "altcha-lib": "^0.5.0"
   },
   "scripts": {
     "start": "node server.js"


### PR DESCRIPTION
引入了Altcha进行人机验证，在频繁vote和请求排行榜时增加了人机验证
Altcha: https://altcha.org/
---
频率限制基于 Upstash Redis 实现
GET /api/altcha/challenge 生成 PoW 挑战
投票验证 每用户每分钟 >5 次投票触发验证
排行榜验证 每 IP 每分钟 >10 次请求触发验证
---
使用前需要在 Vercel 或服务器环境变量中设置 ALTCHA_HMAC_KEY：
生成安全密钥
node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
将输出的密钥设置为 ALTCHA_HMAC_KEY 环境变量。
---
因为涉及到前端和后端的修改，前端的修改只给目前main中存在的chrome版本进行了修改